### PR TITLE
Fix partial flush of compressed content

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,10 @@ module.exports = function compress(options) {
 
       // overwrite the flush method
       res.flush = function(){
-        stream.flush();
+        var ws = stream._writableState;
+        if (ws.ended || ws.ending) return;
+        stream._opts.flush = zlib.Z_PARTIAL_FLUSH;
+        stream.flush(zlib.Z_PARTIAL_FLUSH);
       }
 
       // header fields


### PR DESCRIPTION
In case of open connection (e.g. server sent events), data is not flushed on the go as expected.

I assume it goes down to default _full_ flush mode, switching it to _partial_ fixes the issue.

Cleanest solution I've come up with, is to make a switch to _partial_ mode in case flush is invoked on not yet ended connection.

We need to also override default flush setting for a stream. It's because _kind_ option we pass to `flush` is ignored if flush is postponed due to data not been drained yet -> https://github.com/joyent/node/blob/master/lib/zlib.js#L404-L408
