### PR TITLE
Fix typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Returns the compression middleware using the given `options`.
 
 ```js
 app.use(compress({
-  threshhold: 512
+  threshold: 512
 }))
 ```
 


### PR DESCRIPTION
I copied the example available on the README.md to my project and I took a couple of minutes to discover that the content was being compressed even after increase the threshold value because there was a typo on `threshold` parameter.
