### PR TITLE
Optimize already encoded streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,9 @@ function compression(options) {
       debug('no compression: %s', msg)
       addListeners(res, on, listeners)
       listeners = null
+      res.write = write;
+      res.on = on;
+      res.end = end;
     }
 
     onHeaders(res, function(){


### PR DESCRIPTION
I was doing some performance tests with passing already encoded streams through http-master (https://github.com/encharm/http-master)  (which utilizes expressjs/compression). Weirdly enough there was a big performance hit when doing many requests that simply passed through expressjs/compresison. My initial suspicion was that requests were being re-encoded but no ... the complexity of your `on`, `end` and `write` wrappers was enough to visibly degrade performance. This pull request restores the original function handlers after knowing that stream is not gonna be encoded. 

It completely solved my issue. I would appreciate a merge.