### PR TITLE
Adding brotli support, defaulting to quality:4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 language: node_js
 node_js:
   - "0.8"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following compression codings are supported:
 
   - deflate
   - gzip
+  - brotli
 
 ## Install
 
@@ -135,6 +136,16 @@ The default value is `zlib.Z_DEFAULT_WINDOWBITS`, or `15`.
 
 See [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)
 regarding the usage.
+
+##### brotli
+
+To control the parameters of the brotli algorithm, pass in child object at the key
+`brotli` with one or more of the following brotli algorithm parameters: `lgblock`,
+`lgwin`, `mode`, or `quality`.
+
+Note that unlike the standard brotli library, which defaults to quality 11, this
+library defaults to quality 4, which is [generally more appropriate for dynamic
+content](https://blogs.akamai.com/2016/02/understanding-brotlis-potential.html).
 
 #### .filter
 

--- a/package.json
+++ b/package.json
@@ -13,12 +13,14 @@
     "bytes": "2.2.0",
     "compressible": "~2.0.7",
     "debug": "~2.2.0",
+    "iltorb": "^1.0.9",
     "on-headers": "~1.0.1",
     "vary": "~1.1.0"
   },
   "devDependencies": {
     "istanbul": "0.4.2",
     "mocha": "2.3.4",
+    "stream-buffers": "^3.0.0",
     "supertest": "1.1.0"
   },
   "files": [


### PR DESCRIPTION
I've been very interested in getting brotli support into the Express world, but the consensus has been that brotli is too slow to be a good runtime compression library. However, [a recent article from Akamai](https://blogs.akamai.com/2016/02/understanding-brotlis-potential.html) indicates that this may be incorrect, and that brotli at quality level 4 gives better compression at slightly faster speeds than gzip's default quality setting of 6, making using brotli a win-win even for dynamic content.

This PR attempts to add brotli support to `compression`, using a default quality of 4 so that the usage of brotli runs fast enough to be competitive with gzip.

Given brotli's better compression ratios than gzip, the code in this PR has a strict preference for brotli over gzip or deflate when the client supports it. The PR also maintains the behavior in `master` that prefers gzip over deflate when brotli isn't available.

I've added new tests for the cases I could think of, all tests pass, and coverage remains at 100%.

One thing to note is that I added the module `iltorb`, which is not pure JavaScript. It does, however, compile on both UNIX and Windows as far as I can tell. I'm not sure if you are OK with taking dependencies on native modules or not.

Thanks for all your hard work, and here's hoping we can see this added!