### PR TITLE
Flush alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ function shouldCompress(req, res) {
 This module adds a `res.flush()` method to force the partially-compressed
 response to be flushed to the client.
 
+### res.flushCompression
+
+This is an alias for the `res.flush()` method that is added by this module.
+
+This supports use such as:
+
+```javascript
+// Not going to write again for a while.  If compression middleware is
+// installed let's tell it to flush what we've got through to the client.
+if (res.flushCompression) {
+    res.flushCompression();
+}
+```
+
 ## Examples
 
 ### express/connect

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function compression (options) {
     var _write = res.write
 
     // flush
-    res.flush = function flush () {
+    res.flush = res.flushCompression = function flush() {
       if (stream) {
         stream.flush()
       }

--- a/test/compression.js
+++ b/test/compression.js
@@ -579,6 +579,20 @@ describe('compression()', function () {
       .expect(200, done)
     })
 
+    it('should have a res.flushCompression() alias', function (done) {
+      var server = createServer(null, function (req, res) {
+        res.statusCode = res.flush === res.flushCompression
+          ? 200
+          : 500
+        res.flushCompression()
+        res.end()
+      })
+
+      request(server)
+      .get('/')
+      .expect(200, done)
+    })
+
     it('should flush the response', function (done) {
       var chunks = 0
       var resp


### PR DESCRIPTION
Hi,

This adds `res.flushCompression()` as an alias for `res.flush()`

This supports use such as:

``` javascript
// Not going to write again for a while.  If compression middleware is
// installed let's tell it to flush what we've got through to the client.
if (res.flushCompression) {
    res.flushCompression();
}
```

Currently the `res` object has a `flush` method regardless of whether compression middleware is installed.  The built-in `flush` method issues a noisy deprecation warning.  This patch provides an alias for the `flush` method to allow detection of the compression middleware's `flush`.

This addresses https://github.com/expressjs/compression/issues/72.

Thanks,

Bo
