### PR TITLE
Updated JSDoc to indicate parameter is optional.

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
 /**
  * Compress response data with gzip / deflate.
  *
- * @param {Object} options
+ * @param {Object} [options]
  * @return {Function} middleware
  * @public
  */


### PR DESCRIPTION
WebStorm showed a warning on the empty params ``app.use(compression());`` - that it expected 1 argument.

Updated the JSDoc to show that the param is optional & WebStorm does not show the warning.