### PR TITLE
prevent chunked-compress on connection close

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,10 +252,16 @@ function chunkLength (chunk, encoding) {
 
 function shouldCompress (req, res) {
   var type = res.getHeader('Content-Type')
+  var connection = res.getHeader('Connection')
 
   if (type === undefined || !compressible(type)) {
     debug('%s not compressible', type)
     return false
+  }
+  
+  if (connection === 'close') {
+    debug('transfer cannot be chunked')
+    return false 
   }
 
   return true

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ function shouldCompress (req, res) {
     debug('%s not compressible', type)
     return false
   }
-  
+
   if (connection === 'close') {
     debug('transfer cannot be chunked')
     return false 

--- a/test/compression.js
+++ b/test/compression.js
@@ -46,6 +46,20 @@ describe('compression()', function () {
     .expect('Content-Encoding', 'x-custom')
     .expect(200, 'hello, world', done)
   })
+  
+  it('should skip if connection will be closed', function (done) {
+    var server = createServer({ threshold: 0 }, function (req, res) {
+      res.setHeader('Content-Type', 'text/plain')
+      res.setHeader('Connection', 'close')
+      res.end('hello, world')
+    })
+
+    request(server)
+    .get('/')
+    .set('Accept-Encoding', 'gzip')
+    .expect(shouldNotHaveHeader('Content-Encoding'))
+    .expect(200, done)
+  })
 
   it('should set Vary', function (done) {
     var server = createServer({ threshold: 0 }, function (req, res) {

--- a/test/compression.js
+++ b/test/compression.js
@@ -46,7 +46,7 @@ describe('compression()', function () {
     .expect('Content-Encoding', 'x-custom')
     .expect(200, 'hello, world', done)
   })
-  
+
   it('should skip if connection will be closed', function (done) {
     var server = createServer({ threshold: 0 }, function (req, res) {
       res.setHeader('Content-Type', 'text/plain')


### PR DESCRIPTION
Setting both **Transfer-Encoding: chunked** and **Connection: close** will cause incomplete responses. Connection closes after first chunk, so chunked compression is a bad idea in this case.