### PR TITLE
Update debug module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "accepts": "~1.3.3",
     "bytes": "2.4.0",
     "compressible": "~2.0.9",
-    "debug": "2.6.1",
+    "debug": "2.6.4",
     "on-headers": "~1.0.1",
     "vary": "~1.1.0"
   },


### PR DESCRIPTION
This version fixes the issue described here https://github.com/visionmedia/debug/issues/443
> If process.env.DEBUG is set to a value other than a string a TypeError occurs. This can easily happen when using webpack to build a project.