### PR TITLE
dep: debug@2.6.8

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,12 +5,14 @@ unreleased
   * deps: compressible@~2.0.9
     - Fix regex fallback to not override `compressible: false` in db
     - deps: mime-db@'>= 1.24.0 < 2'
-  * deps: debug@2.6.1
+  * deps: debug@2.6.8
     - Allow colors in workers
     - Deprecated `DEBUG_FD` environment variable set to `3` or higher
+    - Fix DEBUG_MAX_ARRAY_LENGTH
+    - Fix Electron reference to `process.env.DEBUG`
     - Fix error when running under React Native
     - Use same color for same namespace
-    - deps: ms@0.7.2
+    - deps: ms@2.0.0
 
 1.6.2 / 2016-05-12
 ==================

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "accepts": "~1.3.3",
     "bytes": "2.4.0",
     "compressible": "~2.0.9",
-    "debug": "2.6.1",
+    "debug": "2.6.8",
     "on-headers": "~1.0.1",
     "vary": "~1.1.0"
   },


### PR DESCRIPTION
`ms` patched the following vulnerability in v2.0.0 https://snyk.io/vuln/npm:ms:20170412

`debug` updated its `ms` dependency in v2.6.7.

Supersedes https://github.com/expressjs/compression/pull/111

Tracking: https://github.com/digitalbazaar/authorization.io/pull/48 https://github.com/digitalbazaar/bedrock-express/pull/5