### PR TITLE
Fix usage of undocumented _implicitHeader and _header

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,8 +80,8 @@ function compression (options) {
         return false
       }
 
-      if (!this._header) {
-        this._implicitHeader()
+      if (!this.headersSent) {
+        this.writeHead(this.statusCode)
       }
 
       return stream
@@ -94,13 +94,13 @@ function compression (options) {
         return false
       }
 
-      if (!this._header) {
+      if (!this.headersSent) {
         // estimate the length
         if (!this.getHeader('Content-Length')) {
           length = chunkLength(chunk, encoding)
         }
 
-        this._implicitHeader()
+        this.writeHead(this.statusCode)
       }
 
       if (!stream) {


### PR DESCRIPTION
This fixes usage of compression with the http2 node core module where _implicitHeader is not implemented.

Fixes #122 and uses @michael42's proposed solution.

It matches the current [_implicitHeader](https://github.com/nodejs/node/blob/83e5215a4e8438a43b9f0002b7a43e2fd2dd37a4/lib/_http_server.js#L183) implementation. 

I have also changed _header, because while http2 does provide a [compat layer](https://github.com/nodejs/node/blob/0babd181a0c5d775e62a12b3b04fe4d7654fe80a/lib/internal/http2/compat.js#L372), I can't see the reason for using that instead of headersSent. I assume it's there for historical reasons, but headersSent was implemented in v0.9.3, so it should be fine now.

Tests run fine and in my test with an actual http2 server it also works.