### PR TITLE
Fix usage of undocumented _implicitHeader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ node_js:
   - "5.12"
   - "6.14"
   - "7.10"
+  - "8.7" # Keep 8.7 around because it is the last minor on 8.x that didn't have http2
   - "8.11"
   - "9.11"
+  - "10.11"
 sudo: false
 cache:
   directories:

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function compression (options) {
       }
 
       if (!this._header) {
-        this._implicitHeader()
+        this.writeHead(this.statusCode)
       }
 
       return stream
@@ -100,7 +100,7 @@ function compression (options) {
           length = chunkLength(chunk, encoding)
         }
 
-        this._implicitHeader()
+        this.writeHead(this.statusCode)
       }
 
       if (!stream) {

--- a/test/compression.js
+++ b/test/compression.js
@@ -7,8 +7,10 @@ var http = require('http')
 var request = require('supertest')
 var zlib = require('zlib')
 
+var describeHttp2 = describe.skip
 try {
   var http2 = require('http2')
+  describeHttp2 = describe
 } catch (err) {
   if (err) {
     console.log('http2 tests disabled.')
@@ -309,7 +311,7 @@ describe('compression()', function () {
       .expect(200, done)
   })
 
-  if (http2) {
+  describeHttp2('http2', function () {
     it('should work with http2 server', function (done) {
       var server = createHttp2Server({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
@@ -328,7 +330,7 @@ describe('compression()', function () {
         request.end()
       })
     })
-  }
+  })
 
   describe('threshold', function () {
     it('should not compress responses below the threshold size', function (done) {

--- a/test/compression.js
+++ b/test/compression.js
@@ -324,9 +324,11 @@ describe('compression()', function () {
         })
         request.on('response', function (headers) {
           assert.equal(headers['content-encoding'], 'gzip')
-          client.close(function () {
-            server.close(function () {
-              done()
+          request.close(http2.constants.NGHTTP2_NO_ERROR, function () {
+            client.close(function () {
+              server.close(function () {
+                done()
+              })
             })
           })
         })

--- a/test/compression.js
+++ b/test/compression.js
@@ -308,11 +308,13 @@ describe('compression()', function () {
       res.end('hello, world')
     })
 
-    var request = createHttp2Client().request({
+    var client = createHttp2Client()
+    var request = client.request({
       'Accept-Encoding': 'gzip'
     })
-    request.on('response', (headers) => {
+    request.on('response', function (headers) {
       assert.equal(headers['content-encoding'], 'gzip')
+      client.destroy()
       done()
     })
     request.end()

--- a/test/compression.js
+++ b/test/compression.js
@@ -311,21 +311,22 @@ describe('compression()', function () {
 
   if (http2) {
     it('should work with http2 server', function (done) {
-      createHttp2Server({ threshold: 0 }, function (req, res) {
+      var server = createHttp2Server({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
       })
-
-      var client = createHttp2Client()
-      var request = client.request({
-        'Accept-Encoding': 'gzip'
+      server.on('listening', function () {
+        var client = createHttp2Client(server.address().port)
+        var request = client.request({
+          'Accept-Encoding': 'gzip'
+        })
+        request.on('response', function (headers) {
+          assert.equal(headers['content-encoding'], 'gzip')
+          client.destroy()
+          done()
+        })
+        request.end()
       })
-      request.on('response', function (headers) {
-        assert.equal(headers['content-encoding'], 'gzip')
-        client.destroy()
-        done()
-      })
-      request.end()
     })
   }
 
@@ -702,12 +703,12 @@ function createHttp2Server (opts, fn) {
       fn(req, res)
     })
   })
-  server.listen(8443, '127.0.0.1')
+  server.listen(0, '127.0.0.1')
   return server
 }
 
-function createHttp2Client () {
-  var client = http2.connect('http://127.0.0.1:8443')
+function createHttp2Client (port) {
+  var client = http2.connect('http://127.0.0.1:' + port)
   return client
 }
 

--- a/test/compression.js
+++ b/test/compression.js
@@ -4,6 +4,7 @@ var Buffer = require('safe-buffer').Buffer
 var bytes = require('bytes')
 var crypto = require('crypto')
 var http = require('http')
+var http2 = require('http2')
 var request = require('supertest')
 var zlib = require('zlib')
 
@@ -299,6 +300,22 @@ describe('compression()', function () {
       .expect('Content-Encoding', 'gzip')
       .expect(shouldHaveBodyLength(len * 4))
       .expect(200, done)
+  })
+
+  it('should work with http2 server', function (done) {
+    createHttp2Server({ threshold: 0 }, function (req, res) {
+      res.setHeader('Content-Type', 'text/plain')
+      res.end('hello, world')
+    })
+
+    var request = createHttp2Client().request({
+      'Accept-Encoding': 'gzip'
+    })
+    request.on('response', (headers) => {
+      assert.equal(headers['content-encoding'], 'gzip')
+      done()
+    })
+    request.end()
   })
 
   describe('threshold', function () {
@@ -659,6 +676,28 @@ function createServer (opts, fn) {
       fn(req, res)
     })
   })
+}
+
+function createHttp2Server (opts, fn) {
+  var _compression = compression(opts)
+  var server = http2.createServer(function (req, res) {
+    _compression(req, res, function (err) {
+      if (err) {
+        res.statusCode = err.status || 500
+        res.end(err.message)
+        return
+      }
+
+      fn(req, res)
+    })
+  })
+  server.listen(8443, '127.0.0.1')
+  return server
+}
+
+function createHttp2Client () {
+  var client = http2.connect('http://127.0.0.1:8443')
+  return client
 }
 
 function shouldHaveBodyLength (length) {

--- a/test/compression.js
+++ b/test/compression.js
@@ -324,6 +324,14 @@ describe('compression()', function () {
         })
         request.on('response', function (headers) {
           assert.equal(headers['content-encoding'], 'gzip')
+        })
+        request.on('error', function (error) {
+          console.error('An error event occurred on a http2 client request.', error)
+        })
+        request.on('data', function (chunk) {
+          // no-op without which the request will stay open and cause a test timeout
+        })
+        request.on('end', function () {
           closeHttp2(request, client, server, done)
         })
         request.end()
@@ -694,6 +702,12 @@ function createServer (opts, fn) {
 function createHttp2Server (opts, fn) {
   var _compression = compression(opts)
   var server = http2.createServer(function (req, res) {
+    req.on('error', function (error) {
+      console.error('An error event occurred on a http2 request.', error)
+    })
+    res.on('error', function (error) {
+      console.error('An error event occurred on a http2 response.', error)
+    })
     _compression(req, res, function (err) {
       if (err) {
         res.statusCode = err.status || 500
@@ -704,12 +718,21 @@ function createHttp2Server (opts, fn) {
       fn(req, res)
     })
   })
+  server.on('error', function (error) {
+    console.error('An error event occurred on the http2 server.', error)
+  })
+  server.on('sessionError', function (error) {
+    console.error('A sessionError event occurred on the http2 server.', error)
+  })
   server.listen(0, '127.0.0.1')
   return server
 }
 
 function createHttp2Client (port) {
   var client = http2.connect('http://127.0.0.1:' + port)
+  client.on('error', function (error) {
+    console.error('An error event occurred in the http2 client stream.', error)
+  })
   return client
 }
 
@@ -724,9 +747,14 @@ function closeHttp2 (request, client, server, callback) {
       })
     })
   } else {
-    // this is the node v9.x onwards (hopefully) way of closing the connections
+    // this is the node v9.x onwards way of closing the connections
     request.close(http2.constants.NGHTTP2_NO_ERROR, function () {
       client.close(function () {
+        // force existing connections to time out after 1ms.
+        // this is done to force the server to close in some cases where it wouldn't do it otherwise.
+        server.setTimeout(1, function () {
+          console.warn('An http2 connection timed out instead of being closed properly.')
+        })
         server.close(function () {
           callback()
         })

--- a/test/compression.js
+++ b/test/compression.js
@@ -324,8 +324,11 @@ describe('compression()', function () {
         })
         request.on('response', function (headers) {
           assert.equal(headers['content-encoding'], 'gzip')
-          client.destroy()
-          done()
+          client.close(function () {
+            server.close(function () {
+              done()
+            })
+          })
         })
         request.end()
       })

--- a/test/compression.js
+++ b/test/compression.js
@@ -4,9 +4,16 @@ var Buffer = require('safe-buffer').Buffer
 var bytes = require('bytes')
 var crypto = require('crypto')
 var http = require('http')
-var http2 = require('http2')
 var request = require('supertest')
 var zlib = require('zlib')
+
+try {
+  var http2 = require('http2')
+} catch (err) {
+  if (err) {
+    console.log('http2 tests disabled.')
+  }
+}
 
 var compression = require('..')
 
@@ -302,23 +309,25 @@ describe('compression()', function () {
       .expect(200, done)
   })
 
-  it('should work with http2 server', function (done) {
-    createHttp2Server({ threshold: 0 }, function (req, res) {
-      res.setHeader('Content-Type', 'text/plain')
-      res.end('hello, world')
-    })
+  if (http2) {
+    it('should work with http2 server', function (done) {
+      createHttp2Server({ threshold: 0 }, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
 
-    var client = createHttp2Client()
-    var request = client.request({
-      'Accept-Encoding': 'gzip'
+      var client = createHttp2Client()
+      var request = client.request({
+        'Accept-Encoding': 'gzip'
+      })
+      request.on('response', function (headers) {
+        assert.equal(headers['content-encoding'], 'gzip')
+        client.destroy()
+        done()
+      })
+      request.end()
     })
-    request.on('response', function (headers) {
-      assert.equal(headers['content-encoding'], 'gzip')
-      client.destroy()
-      done()
-    })
-    request.end()
-  })
+  }
 
   describe('threshold', function () {
     it('should not compress responses below the threshold size', function (done) {

--- a/test/compression.js
+++ b/test/compression.js
@@ -324,13 +324,7 @@ describe('compression()', function () {
         })
         request.on('response', function (headers) {
           assert.equal(headers['content-encoding'], 'gzip')
-          request.close(http2.constants.NGHTTP2_NO_ERROR, function () {
-            client.close(function () {
-              server.close(function () {
-                done()
-              })
-            })
-          })
+          closeHttp2(request, client, server, done)
         })
         request.end()
       })
@@ -717,6 +711,28 @@ function createHttp2Server (opts, fn) {
 function createHttp2Client (port) {
   var client = http2.connect('http://127.0.0.1:' + port)
   return client
+}
+
+function closeHttp2 (request, client, server, callback) {
+  if (typeof client.shutdown === 'function') {
+    // this is the node v8.x way of closing the connections
+    request.destroy(http2.constants.NGHTTP2_NO_ERROR, function () {
+      client.shutdown({}, function () {
+        server.close(function () {
+          callback()
+        })
+      })
+    })
+  } else {
+    // this is the node v9.x onwards (hopefully) way of closing the connections
+    request.close(http2.constants.NGHTTP2_NO_ERROR, function () {
+      client.close(function () {
+        server.close(function () {
+          callback()
+        })
+      })
+    })
+  }
 }
 
 function shouldHaveBodyLength (length) {


### PR DESCRIPTION
As discussed in #127 this PR now only includes the changes that should not break node v0.8 and has tests.

Sadly supertest does not support http2 yet, so I had to resort to vanilla server/client creation.

I'm not destroying the client/server here, not sure if that's needed?!