### PR TITLE
Prevent multiple injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,9 +68,9 @@ function compression (options) {
 
     // prevent compression from being injected twice.
     if (res._compressionEnabled === true) {
-      return;
+      return
     }
-    res._compressionEnabled = true;
+    res._compressionEnabled = true
 
     // flush
     res.flush = function flush () {

--- a/index.js
+++ b/index.js
@@ -66,6 +66,12 @@ function compression (options) {
     var _on = res.on
     var _write = res.write
 
+    // prevent compression from being injected twice.
+    if (res._compressionEnabled === true) {
+      return;
+    }
+    res._compressionEnabled = true;
+
     // flush
     res.flush = function flush () {
       if (stream) {


### PR DESCRIPTION
Currently, it's possible to apply the compression middleware multiple times, which has undesirable effects. This is particularly easy to do when using Express's `Router`, as a given Router can install compression but have it bleed into all subsequent middleware & handlers.

This PR introduces a flag on Response objects indicating whether compression has been injected into the response methods, and uses that flag to avoid re-injecting compression.

_Issues: this might break composability? I don't know if people have valid use-cases for running multiple instances of this middleware today._