### PR TITLE
feat: Adding support for brolti

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The following compression codings are supported:
 
   - deflate
   - gzip
+  - br (brotli)
+
+**Note** Brotli is supported only since Node.js versions v11.7.0 and v10.16.0.
 
 ## Install
 
@@ -44,7 +47,8 @@ as compressing will transform the body.
 
 `compression()` accepts these properties in the options object. In addition to
 those listed below, [zlib](http://nodejs.org/api/zlib.html) options may be
-passed in to the options object.
+passed in to the options object or
+[brotli](https://nodejs.org/api/zlib.html#zlib_class_brotlioptions) options.
 
 ##### chunkSize
 
@@ -101,6 +105,20 @@ The default value is `zlib.Z_DEFAULT_MEMLEVEL`, or `8`.
 See [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)
 regarding the usage.
 
+##### params *(brotli only)* - [key-value object containing indexed Brotli parameters](https://nodejs.org/api/zlib.html#zlib_brotli_constants)
+
+  - `zlib.constants.BROTLI_PARAM_MODE`
+    - `zlib.constants.BROTLI_MODE_GENERIC` (default)
+    - `zlib.constants.BROTLI_MODE_TEXT`, adjusted for UTF-8 text
+    - `zlib.constants.BROTLI_MODE_FONT`, adjusted for WOFF 2.0 fonts
+  - `zlib.constants.BROTLI_PARAM_QUALITY`
+    - Ranges from `zlib.constants.BROTLI_MIN_QUALITY` to
+      `zlib.constants.BROTLI_MAX_QUALITY`, with a default of
+      `4` (which is not node's default but the most optimal).
+
+Note that here the default is set to compression level 4. This is a balanced setting with a very good speed and a very good
+compression ratio.
+
 ##### strategy
 
 This is used to tune the compression algorithm. This value only affects the
@@ -140,6 +158,14 @@ The default value is `zlib.Z_DEFAULT_WINDOWBITS`, or `15`.
 
 See [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)
 regarding the usage.
+
+##### preferClient
+
+This library by default will prioritize the optimal compression encoding algorithm if the client has
+given more than one encoding the same explicit "quality". This is generally what users want and it 
+follows an established pattern used by other popular web servers. If you would like to opt-out of this
+behavior (and therefore be more spec compliant), you can set `preferClient` to "true" and when
+two encodings have the same "quality" the first one will be used.
 
 #### .filter
 

--- a/index.js
+++ b/index.js
@@ -328,6 +328,9 @@ function toBuffer (chunk, encoding) {
  * @private
  */
 function prioritize (str) {
+  if(str == undefined) {
+    return undefined
+  }
   return str
     .split(',')
     .sort(sortEncodings)

--- a/index.js
+++ b/index.js
@@ -341,8 +341,8 @@ function prioritize (str) {
  * @private
  */
 function sortEncodings (a, b) {
-  var al = a.toLowerCase();
-  var bl = b.toLowerCase();
+  var al = a.toLowerCase()
+  var bl = b.toLowerCase()
   if (al.indexOf('br') >= 0) {
     return -1
   }

--- a/index.js
+++ b/index.js
@@ -199,8 +199,11 @@ function compression (options) {
       // force proper priorization
       var headers = objectAssign({}, req.headers, options.prioritizeClient ? null : { 'accept-encoding': prioritize(req.headers['accept-encoding']) })
 
-      // compression method
+      // the accepts function takes in a request object but only reads the headers
+      // So, to save a bit of memory, we send an object with only the headers propery
+      // this way we don't have to clone the entire request
       var accept = accepts({ headers: headers })
+      // compression method
       var method = accept.encoding(preferredEncodings)
 
       // negotiation failed
@@ -325,7 +328,7 @@ function toBuffer (chunk, encoding) {
  * @private
  */
 function prioritize (str) {
-  return str && str.toLowerCase()
+  return str
     .split(',')
     .sort(sortEncodings)
     .join(',')
@@ -338,18 +341,20 @@ function prioritize (str) {
  * @private
  */
 function sortEncodings (a, b) {
-  if (a.indexOf('br') >= 0) {
+  var al = a.toLowerCase();
+  var bl = b.toLowerCase();
+  if (al.indexOf('br') >= 0) {
     return -1
   }
-  if (a.indexOf('gzip') >= 0) {
-    return b.indexOf('br') >= 0 ? 1 : -1
+  if (al.indexOf('gzip') >= 0) {
+    return bl.indexOf('br') >= 0 ? 1 : -1
   }
   // we need these inverse rules to fix a stable sort bug
   // found in node 10.x
-  if (b.indexOf('br') >= 0) {
+  if (bl.indexOf('br') >= 0) {
     return 1
   }
-  if (b.indexOf('gzip') >= 0) {
+  if (bl.indexOf('gzip') >= 0) {
     return 1
   }
   return 0

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bytes": "3.0.0",
     "compressible": "~2.0.17",
     "debug": "2.6.9",
+    "object-assign": "4.1.1",
     "on-headers": "~1.0.2",
     "safe-buffer": "5.2.0",
     "vary": "~1.1.2"


### PR DESCRIPTION
Fixes #71 

## TL;DR
There has been several attempts (#172, #158) to add [brotli compression](https://en.wikipedia.org/wiki/Brotli) support to this library and so far none have been successfully merged (for various reasons). This PR is yet another attempt to support brotli compression in a backwards compatible way while also reducing existing code change as much as possible to ensure stability of the library.

## What is the problem that is trying to be solved?
The brotli compression algorithm is generally more efficient than gzip and now supported in recent versions of Node.js and in all major browsers. Http clients (like web browsers) can specify an "Accept-Encoding" header in their requests to share which compression algorithms they support and prefer. According to the spec, when two values have the same preference, the first value will be used (seems reasonable right?). 

However, many browsers (including Google Chrome) send the "br" (brotli) value last even though it is generally preferred to the other algorithms (ie they send `gzip, deflate, br` instead of `br, gzip, deflate`). This causes the brotli compression algorithm to be de-prioritized and unused. 

## What can we do about it?
We can follow a well-established convention to deviate from the spec slightly and force the server to choose the "preferred" compression algorithm when the client has (basically) stated that it doesn't not explicitly prefer one algorithm over another.

So, for example, if we get an "Accept-Encoding" header value of `gzip, deflate, br` we will use `br` (brotli) because brotli is more efficient over gzip and their preference (set by client) is both 1 (the default value). 

However, if we get `gzip;q=0.8, br;q=0.1` (q is level of preference from 0 to 1 where 1 is most preferred) we will use 'gzip' because the client has *explicitly* stated that it is more preferred than brotli.