### PR TITLE
deps: bytes@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "repository": "expressjs/compression",
   "dependencies": {
     "accepts": "~1.3.7",
-    "bytes": "3.0.0",
+    "bytes": "3.1.0",
     "compressible": "~2.0.17",
     "debug": "2.6.9",
     "on-headers": "~1.0.2",


### PR DESCRIPTION
Other Express-related packages like `body-parser` and `raw-body` require `bytes@3.1.0` so upgrading this dependency in `compression` saves a copy of `bytes` on all installations that combine `express` and `compression`.