### PR TITLE
Do not swallow calls to `res.end()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,6 +232,11 @@ function compression (options) {
         stream.resume()
       })
 
+      // In case the stream is paused when the response finishes (e.g.  because
+      // the client cuts the connection), its `drain` event may not get emitted.
+      // The following handler is here to ensure that the stream gets resumed so
+      // it ends up emitting its `end` event and calling the original
+      // `res.end()`.
       finished(res, function onResponseFinished () {
         stream.resume()
       })

--- a/index.js
+++ b/index.js
@@ -216,7 +216,10 @@ function compression (options) {
 
       // compression
       stream.on('data', function onStreamData (chunk) {
-        if (_write.call(res, chunk) === false && !isFinished(res)) {
+        if (isFinished(res)) {
+          return
+        }
+        if (_write.call(res, chunk) === false) {
           stream.pause()
         }
       })

--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function compression (options) {
         stream.resume()
       })
 
-      nodeStream.finished(res, function onResponseFinished () {
+      finished(res, function onResponseFinished () {
         if (ended) {
           endOnce.call(res)
         }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ var Negotiator = require('negotiator')
 var bytes = require('bytes')
 var compressible = require('compressible')
 var debug = require('debug')('compression')
-var onFinished = require('on-finished')
 var onHeaders = require('on-headers')
 var vary = require('vary')
 var zlib = require('zlib')
@@ -129,7 +128,7 @@ function compression (options) {
       // mark ended
       ended = true
 
-      if (onFinished.isFinished(this)) {
+      if (this.writableFinished || !this.socket.writable) {
         return endOnce.call(this)
       }
 
@@ -241,7 +240,7 @@ function compression (options) {
         stream.resume()
       })
 
-      onFinished(res, function onFinished () {
+      res.socket.on('close', function onSocketClose () {
         if (ended) {
           endOnce.call(res)
         }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var Negotiator = require('negotiator')
 var bytes = require('bytes')
 var compressible = require('compressible')
 var debug = require('debug')('compression')
+var onFinished = require('on-finished')
 var onHeaders = require('on-headers')
 var vary = require('vary')
 var zlib = require('zlib')
@@ -119,6 +120,10 @@ function compression (options) {
 
       // mark ended
       ended = true
+
+      if (onFinished.isFinished(this)) {
+        return _end.call(this)
+      }
 
       // write Buffer for Node.js 0.8
       return chunk
@@ -226,6 +231,12 @@ function compression (options) {
 
       _on.call(res, 'drain', function onResponseDrain () {
         stream.resume()
+      })
+
+      onFinished(res, function onFinished () {
+        if (ended) {
+          _end.call(res)
+        }
       })
     })
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
  * @private
  */
 
-var nodeStream = require('node:stream')
+var { finished } = require('node:stream')
 var Negotiator = require('negotiator')
 var bytes = require('bytes')
 var compressible = require('compressible')

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var Negotiator = require('negotiator')
 var bytes = require('bytes')
 var compressible = require('compressible')
 var debug = require('debug')('compression')
+const isFinished = require('on-finished').isFinished
 var onHeaders = require('on-headers')
 var vary = require('vary')
 var zlib = require('zlib')
@@ -217,9 +218,11 @@ function compression (options) {
       // compression
       stream.on('data', function onStreamData (chunk) {
         if (isFinished(res)) {
+          debug('response finished')
           return
         }
         if (_write.call(res, chunk) === false) {
+          debug('pausing compression stream')
           stream.pause()
         }
       })
@@ -310,15 +313,4 @@ function toBuffer (chunk, encoding) {
   return Buffer.isBuffer(chunk)
     ? chunk
     : Buffer.from(chunk, encoding)
-}
-
-/**
- * Determine if the response is finished.
- *
- * @param {object} res
- * @returns {boolean}
- * @private
- */
-function isFinished (res) {
-  return res.writableFinished || !res.socket.writable
 }

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@
  * @private
  */
 
+var nodeStream = require('node:stream')
 var Negotiator = require('negotiator')
 var bytes = require('bytes')
 var compressible = require('compressible')
@@ -240,7 +241,7 @@ function compression (options) {
         stream.resume()
       })
 
-      res.socket.on('close', function onSocketClose () {
+      nodeStream.finished(res, function onResponseFinished () {
         if (ended) {
           endOnce.call(res)
         }

--- a/index.js
+++ b/index.js
@@ -77,14 +77,6 @@ function compression (options) {
     var _on = res.on
     var _write = res.write
 
-    var endCalled = false
-    function endOnce () {
-      if (!endCalled) {
-        endCalled = true
-        _end.apply(this, arguments)
-      }
-    }
-
     // flush
     res.flush = function flush () {
       if (stream) {
@@ -123,7 +115,7 @@ function compression (options) {
       }
 
       if (!stream) {
-        return endOnce.call(this, chunk, encoding)
+        return _end.call(this, chunk, encoding)
       }
 
       // mark ended
@@ -230,7 +222,7 @@ function compression (options) {
       })
 
       stream.on('end', function onStreamEnd () {
-        endOnce.call(res)
+        _end.call(res)
       })
 
       _on.call(res, 'drain', function onResponseDrain () {

--- a/index.js
+++ b/index.js
@@ -77,6 +77,14 @@ function compression (options) {
     var _on = res.on
     var _write = res.write
 
+    var endCalled = false
+    function endOnce () {
+      if (!endCalled) {
+        endCalled = true
+        _end.apply(this, arguments)
+      }
+    }
+
     // flush
     res.flush = function flush () {
       if (stream) {
@@ -115,14 +123,14 @@ function compression (options) {
       }
 
       if (!stream) {
-        return _end.call(this, chunk, encoding)
+        return endOnce.call(this, chunk, encoding)
       }
 
       // mark ended
       ended = true
 
       if (onFinished.isFinished(this)) {
-        return _end.call(this)
+        return endOnce.call(this)
       }
 
       // write Buffer for Node.js 0.8
@@ -226,7 +234,7 @@ function compression (options) {
       })
 
       stream.on('end', function onStreamEnd () {
-        _end.call(res)
+        endOnce.call(res)
       })
 
       _on.call(res, 'drain', function onResponseDrain () {
@@ -235,7 +243,7 @@ function compression (options) {
 
       onFinished(res, function onFinished () {
         if (ended) {
-          _end.call(res)
+          endOnce.call(res)
         }
       })
     })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "compressible": "~2.0.18",
     "debug": "2.6.9",
     "negotiator": "~0.6.4",
-    "on-finished": "~2.3.0",
     "on-headers": "~1.0.2",
     "vary": "~1.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compressible": "^2.0.18",
     "debug": "^2.6.9",
     "negotiator": "^0.6.4",
+    "on-finished": "^2.4.1",
     "on-headers": "^1.0.2",
     "vary": "^1.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compressible": "~2.0.18",
     "debug": "2.6.9",
     "negotiator": "~0.6.4",
+    "on-finished": "~2.3.0",
     "on-headers": "~1.0.2",
     "vary": "~1.1.2"
   },

--- a/test/compression.js
+++ b/test/compression.js
@@ -1107,7 +1107,7 @@ describe('compression()', function () {
         var writeError = null
         res.write = function (chunk, callback) {
           return originalWrite.call(this, chunk, function (error) {
-            if (error?.code === 'ERR_STREAM_WRITE_AFTER_END') {
+            if (error) {
               writeError = error
             }
             return callback?.(error)

--- a/test/compression.js
+++ b/test/compression.js
@@ -3,6 +3,7 @@ var assert = require('assert')
 var bytes = require('bytes')
 var crypto = require('crypto')
 var http = require('http')
+var net = require('net')
 var request = require('supertest')
 var zlib = require('zlib')
 var http2 = require('http2')
@@ -953,6 +954,113 @@ describe('compression()', function () {
         .expect(200, done)
     })
   })
+
+  describe('when the client closes the connection before consuming the response', function () {
+    it('should call the original res.end() if connection is cut early on', function (done) {
+      var server = http.createServer(function (req, res) {
+        var originalResEnd = res.end
+        var originalResEndCalledTimes = 0
+        res.end = function () {
+          originalResEndCalledTimes++
+          return originalResEnd.apply(this, arguments)
+        }
+
+        compression({ threshold: 0 })(req, res, function () {
+          socket.end()
+
+          res.setHeader('Content-Type', 'text/plain')
+          res.write('hello, ')
+          setTimeout(function () {
+            res.end('world!')
+
+            setTimeout(function () {
+              server.close(function () {
+                if (originalResEndCalledTimes === 1) {
+                  done()
+                } else {
+                  done(new Error('The original res.end() was called ' + originalResEndCalledTimes + ' times'))
+                }
+              })
+            }, 5)
+          }, 5)
+        })
+      })
+
+      server.listen()
+
+      var port = server.address().port
+      var socket = openSocketWithRequest(port)
+    })
+
+    it('should call the original res.end() if connection is cut after an initial write', function (done) {
+      var server = http.createServer(function (req, res) {
+        var originalResEnd = res.end
+        var originalResEndCalledTimes = 0
+        res.end = function () {
+          originalResEndCalledTimes++
+          return originalResEnd.apply(this, arguments)
+        }
+
+        compression({ threshold: 0 })(req, res, function () {
+          res.setHeader('Content-Type', 'text/plain')
+          res.write('hello, ')
+          socket.end()
+
+          setTimeout(function () {
+            res.end('world!')
+
+            setTimeout(function () {
+              server.close(function () {
+                if (originalResEndCalledTimes === 1) {
+                  done()
+                } else {
+                  done(new Error('The original res.end() was called ' + originalResEndCalledTimes + ' times'))
+                }
+              })
+            }, 5)
+          }, 5)
+        })
+      })
+
+      server.listen()
+
+      var port = server.address().port
+      var socket = openSocketWithRequest(port)
+    })
+
+    it('should call the original res.end() if connection is cut just after response body was generated', function (done) {
+      var server = http.createServer(function (req, res) {
+        var originalResEnd = res.end
+        var originalResEndCalledTimes = 0
+        res.end = function () {
+          originalResEndCalledTimes++
+          return originalResEnd.apply(this, arguments)
+        }
+
+        compression({ threshold: 0 })(req, res, function () {
+          res.setHeader('Content-Type', 'text/plain')
+          res.write('hello, ')
+          res.end('world!')
+          socket.end()
+
+          setTimeout(function () {
+            server.close(function () {
+              if (originalResEndCalledTimes === 1) {
+                done()
+              } else {
+                done(new Error('The original res.end() was called ' + originalResEndCalledTimes + ' times'))
+              }
+            })
+          }, 5)
+        })
+      })
+
+      server.listen()
+
+      var port = server.address().port
+      var socket = openSocketWithRequest(port)
+    })
+  })
 })
 
 function createServer (opts, fn) {
@@ -1055,4 +1163,17 @@ function unchunk (encoding, onchunk, onend) {
     stream.on('data', onchunk)
     stream.on('end', onend)
   }
+}
+
+function openSocketWithRequest (port) {
+  var socket = net.connect(port, function onConnect () {
+    socket.write('GET / HTTP/1.1\r\n')
+    socket.write('Accept-Encoding: gzip\r\n')
+    socket.write('Host: localhost:' + port + '\r\n')
+    socket.write('Content-Type: text/plain\r\n')
+    socket.write('Content-Length: 0\r\n')
+    socket.write('Connection: keep-alive\r\n')
+    socket.write('\r\n')
+  })
+  return socket
 }


### PR DESCRIPTION
# Background

In our application we tend to rely on `res.end()` calls to perform cleanup. Specifically, we intercept those calls, similarly to how [the same is done in the `compression` middleware](https://github.com/expressjs/compression/blob/f3e6f389cb87e090438e13c04d67cec9e22f8098/index.js#L92-L117), and take custom actions before calling the original `res.end` function. 

Recently we found out that depending on middleware order, our cleanup code either gets called reliably or it does not. Additional investigation revealed that it is the `compression` middleware that sometimes "swallows" calls to `res.end`, which is to say that even though a route handler calls `res.end`, the middleware never calls [the original `res.end` function](https://github.com/expressjs/compression/blob/f3e6f389cb87e090438e13c04d67cec9e22f8098/index.js#L65). In particular, this happens when the client cuts the connection before consuming the compressed response because the following happens:

1. Since the connection is cut, bytes cannot continue to be written into the response, and [the compressed stream gets paused](https://github.com/expressjs/compression/blob/f3e6f389cb87e090438e13c04d67cec9e22f8098/index.js#L206-L208).
1. Once the route handler calls `res.end`, the `compression` middleware [does not call the original `res.end` function](https://github.com/expressjs/compression/blob/f3e6f389cb87e090438e13c04d67cec9e22f8098/index.js#L106-L108) and instead [calls `stream.end`](https://github.com/expressjs/compression/blob/f3e6f389cb87e090438e13c04d67cec9e22f8098/index.js#L114-L116).
1. Since the data in the stream is not entirely consumed, [the `end` event does not get emitted](https://nodejs.org/api/stream.html#event-end) and [the handler attached to it never calls the original `res.end` function](https://github.com/expressjs/compression/blob/f3e6f389cb87e090438e13c04d67cec9e22f8098/index.js#L211-L213).

We considered using the [`finish`](https://nodejs.org/api/http.html#event-finish_2) or [`prefinish`](https://nodejs.org/api/http.html#event-prefinish) events instead of wrapping `res.end` calls, but these do not get emitted either, likely because `OutgoingMessage.end` never gets called either.

# Change

1. Adds tests covering a few scenarios under which the original `res.end` function does not get called with the code on `master`
1. Uses `on-finished` to detect client disconnect and call the original `res.end` function - though this is _only_ done if the replacement `res.end` wrapper had already been called, or if it is currently being called
1. Due to the added call sites for the original `res.end` function, the changed code also ensures that we never call the function more than once

Overall, the change should ensure that `res.end` calls do not get swallowed by the `compression` middleware.

# Acknowledgement

Lots of the ideation around this change as well as the test code originate from @papandreou - many thanks for all the help! 🙇 