### PR TITLE
feat: add default option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 unreleased
 ==========
-
+  * Add the defaultEncoding option for requests without `Accept-Encoding` header
   * deps: accepts@~1.3.8
     - Fix sorting encoding with extra parameters
     - deps: mime-types@~2.1.34

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 unreleased
 ==========
-  * Add the defaultEncoding option for requests without `Accept-Encoding` header
+  * Add the enforceEncoding option for requests without `Accept-Encoding` header
 
 1.7.5 / 2024-10-31
 ==========

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ The default value is `zlib.Z_DEFAULT_WINDOWBITS`, or `15`.
 See [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)
 regarding the usage.
 
+##### defaultEncoding
+
+This is the default encoding to use when the client does not specify an encoding in the request's [Accept-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header.
+
+The default value is `identity`.
+
 #### .filter
 
 The default `filter` function. This is used to construct a custom filter

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The default value is `zlib.Z_DEFAULT_WINDOWBITS`, or `15`.
 See [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)
 regarding the usage.
 
-##### defaultEncoding
+##### enforceEncoding
 
 This is the default encoding to use when the client does not specify an encoding in the request's [Accept-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header.
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ module.exports.filter = shouldCompress
 
 var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
 
+var encodingSupported = ['gzip', 'deflate', 'identity']
+
 /**
  * Compress response data with gzip / deflate.
  *
@@ -51,6 +53,7 @@ function compression (options) {
   // options
   var filter = opts.filter || shouldCompress
   var threshold = bytes.parse(opts.threshold)
+  var defaultEncoding = opts.defaultEncoding || 'identity'
 
   if (threshold == null) {
     threshold = 1024
@@ -182,10 +185,19 @@ function compression (options) {
         method = accept.encoding(['gzip', 'identity'])
       }
 
+      // if no method is found, use the default encoding
+      if (encodingSupported.indexOf(defaultEncoding) !== -1 && req.headers['accept-encoding'].split(',')[0] === '') {
+        method = defaultEncoding
+      }
+
       // negotiation failed
       if (!method || method === 'identity') {
         nocompress('not acceptable')
         return
+      }
+
+      if (opts.defaultEncoding) {
+        opts.defaultEncoding = undefined
       }
 
       // compression stream

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports.filter = shouldCompress
 
 var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
 
-var encodingSupported = ['gzip', 'deflate', 'identity']
+var encodingSupported = ['*', 'gzip', 'deflate', 'identity']
 
 /**
  * Compress response data with gzip / deflate.
@@ -187,7 +187,7 @@ function compression (options) {
 
       // if no method is found, use the default encoding
       if (encodingSupported.indexOf(defaultEncoding) !== -1 && req.headers['accept-encoding'].split(',')[0] === '') {
-        method = defaultEncoding
+        method = defaultEncoding === '*' ? 'gzip' : defaultEncoding
       }
 
       // negotiation failed

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ function compression (options) {
       }
 
       // if no method is found, use the default encoding
-      if (encodingSupported.indexOf(defaultEncoding) !== -1 && req.headers['accept-encoding'].split(',')[0] === '') {
+      if (encodingSupported.indexOf(defaultEncoding) !== -1 && !req.headers['accept-encoding']) {
         method = defaultEncoding === '*' ? 'gzip' : defaultEncoding
       }
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function compression (options) {
   // options
   var filter = opts.filter || shouldCompress
   var threshold = bytes.parse(opts.threshold)
-  var defaultEncoding = opts.defaultEncoding || 'identity'
+  var enforceEncoding = opts.enforceEncoding || 'identity'
 
   if (threshold == null) {
     threshold = 1024
@@ -181,18 +181,14 @@ function compression (options) {
       var method = negotiator.encoding(['gzip', 'deflate', 'identity'], ['gzip'])
 
       // if no method is found, use the default encoding
-      if (encodingSupported.indexOf(defaultEncoding) !== -1 && !req.headers['accept-encoding']) {
-        method = defaultEncoding === '*' ? 'gzip' : defaultEncoding
+      if (encodingSupported.indexOf(enforceEncoding) !== -1 && !req.headers['accept-encoding']) {
+        method = enforceEncoding === '*' ? 'gzip' : enforceEncoding
       }
 
       // negotiation failed
       if (!method || method === 'identity') {
         nocompress('not acceptable')
         return
-      }
-
-      if (opts.defaultEncoding) {
-        opts.defaultEncoding = undefined
       }
 
       // compression stream

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function compression (options) {
       var method = negotiator.encoding(['gzip', 'deflate', 'identity'], ['gzip'])
 
       // if no method is found, use the default encoding
-      if (encodingSupported.indexOf(enforceEncoding) !== -1 && !req.headers['accept-encoding']) {
+      if (!req.headers['accept-encoding'] && encodingSupported.indexOf(enforceEncoding) !== -1) {
         method = enforceEncoding === '*' ? 'gzip' : enforceEncoding
       }
 

--- a/test/compression.js
+++ b/test/compression.js
@@ -658,9 +658,9 @@ describe('compression()', function () {
     })
   })
 
-  describe('defaultEncoding', function () {
+  describe('enforceEncoding', function () {
     it('should compress the provided encoding and not the default encoding', function (done) {
-      var server = createServer({ threshold: 0, defaultEncoding: 'deflate' }, function (req, res) {
+      var server = createServer({ threshold: 0, enforceEncoding: 'deflate' }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
       })
@@ -672,8 +672,8 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    it('should not compress when defaultEncoding is identity', function (done) {
-      var server = createServer({ threshold: 0, defaultEncoding: 'identity' }, function (req, res) {
+    it('should not compress when enforceEncoding is identity', function (done) {
+      var server = createServer({ threshold: 0, enforceEncoding: 'identity' }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
       })
@@ -685,8 +685,8 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    it('should compress when defaultEncoding is gzip', function (done) {
-      var server = createServer({ threshold: 0, defaultEncoding: 'gzip' }, function (req, res) {
+    it('should compress when enforceEncoding is gzip', function (done) {
+      var server = createServer({ threshold: 0, enforceEncoding: 'gzip' }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
       })
@@ -698,8 +698,8 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    it('should compress when defaultEncoding is deflate', function (done) {
-      var server = createServer({ threshold: 0, defaultEncoding: 'deflate' }, function (req, res) {
+    it('should compress when enforceEncoding is deflate', function (done) {
+      var server = createServer({ threshold: 0, enforceEncoding: 'deflate' }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
       })
@@ -711,8 +711,8 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    it('should not compress when defaultEncoding is unknown', function (done) {
-      var server = createServer({ threshold: 0, defaultEncoding: 'bogus' }, function (req, res) {
+    it('should not compress when enforceEncoding is unknown', function (done) {
+      var server = createServer({ threshold: 0, enforceEncoding: 'bogus' }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
       })
@@ -724,8 +724,8 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    it('should be gzip if no accept-encoding is sent when defaultEncoding is *', function (done) {
-      var server = createServer({ threshold: 0, defaultEncoding: '*' }, function (req, res) {
+    it('should be gzip if no accept-encoding is sent when enforceEncoding is *', function (done) {
+      var server = createServer({ threshold: 0, enforceEncoding: '*' }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
       })

--- a/test/compression.js
+++ b/test/compression.js
@@ -657,6 +657,73 @@ describe('compression()', function () {
         .end()
     })
   })
+
+  describe('defaultEncoding', function () {
+    it('should compress the provided encoding and not the default encoding', function (done) {
+      var server = createServer({ threshold: 0, defaultEncoding: 'deflate' }, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should not compress when defaultEncoding is identity', function (done) {
+      var server = createServer({ threshold: 0, defaultEncoding: 'identity' }, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', '')
+        .expect(shouldNotHaveHeader('Content-Encoding'))
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should compress when defaultEncoding is gzip', function (done) {
+      var server = createServer({ threshold: 0, defaultEncoding: 'gzip' }, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', '')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should compress when defaultEncoding is deflate', function (done) {
+      var server = createServer({ threshold: 0, defaultEncoding: 'deflate' }, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', '')
+        .expect('Content-Encoding', 'deflate')
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should not compress when defaultEncoding is unknown', function (done) {
+      var server = createServer({ threshold: 0, defaultEncoding: 'bogus' }, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', '')
+        .expect(shouldNotHaveHeader('Content-Encoding'))
+        .expect(200, 'hello, world', done)
+    })
+  })
 })
 
 function createServer (opts, fn) {

--- a/test/compression.js
+++ b/test/compression.js
@@ -723,6 +723,19 @@ describe('compression()', function () {
         .expect(shouldNotHaveHeader('Content-Encoding'))
         .expect(200, 'hello, world', done)
     })
+
+    it('should be gzip if no accept-encoding is sent when defaultEncoding is *', function (done) {
+      var server = createServer({ threshold: 0, defaultEncoding: '*' }, function (req, res) {
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', '')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, 'hello, world', done)
+    })
   })
 })
 


### PR DESCRIPTION
A new option is added to determine the default behavior when `Accept-Encoding` is not sent by the client, defaulting to identity.

closes #83