### PR TITLE
Refactor toBuffer function to simplify buffer check logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ function shouldTransform (req, res) {
  */
 
 function toBuffer (chunk, encoding) {
-  return !Buffer.isBuffer(chunk)
-    ? Buffer.from(chunk, encoding)
-    : chunk
+  return Buffer.isBuffer(chunk)
+    ? chunk
+    : Buffer.from(chunk, encoding)
 }


### PR DESCRIPTION
The function now directly returns the existing buffer if the input is already a buffer, eliminating the need for a negated condition. This improves code readability and maintains functionality by ensuring that non-buffer inputs are converted to a buffer using the specified encoding.