### PR TITLE
ci: update ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,41 @@
 name: ci
 
 on:
-- pull_request
-- push
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '*.md'
+  push:
+    paths-ignore:
+      - '*.md'
+
+permissions:
+  contents: read
+
+# Cancel in progress workflows
+# in the scenario where we already had a run going for that PR/branch/tag but then triggered a new run
+concurrency:
+  group: "${{ github.workflow }} ✨ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts --only=dev
+
+      - name: Run lint
+        run: npm run lint
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -195,24 +226,39 @@ jobs:
           npm test
         fi
 
-    - name: Lint code
-      if: steps.list_env.outputs.eslint != ''
-      run: npm run lint
-
-    - name: Collect code coverage
-      uses: coverallsapp/github-action@master
+    - name: Upload code coverage
       if: steps.list_env.outputs.nyc != ''
+      uses: actions/upload-artifact@v4
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: run-${{ matrix.test_number }}
-        parallel: true
+        name: coverage-node-${{ matrix.node-version }}
+        path: ./coverage/lcov.info
+        retention-days: 1
 
   coverage:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
-    - name: Upload code coverage
-      uses: coverallsapp/github-action@master
+    - uses: actions/checkout@v4
+
+    - name: Install lcov
+      shell: bash
+      run: sudo apt-get -y install lcov
+
+    - name: Collect coverage reports
+      uses: actions/download-artifact@v4
       with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true
+        path: ./coverage
+        pattern: coverage-node-*
+
+    - name: Merge coverage reports
+      shell: bash
+      run: find ./coverage -name lcov.info -exec printf '-a %q\n' {} \; | xargs lcov -o ./lcov.info
+
+    - name: Upload coverage report
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        file: ./lcov.info

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --check-leaks --reporter spec",
-    "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
+    "test-ci": "nyc --reporter=lcov --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
   }
 }


### PR DESCRIPTION
Part of the CI in Express was adapted to separate the linter from the test, in addition to updating some GitHub actions