### PR TITLE
ci: add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: deps
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
-
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-    commit-message:
-      prefix: deps
+      interval: monthly
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+      time: "23:00"
+      timezone: Europe/London
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

According to this [comment](https://github.com/expressjs/express/pull/5435#issuecomment-2483734320), dependabot will be used for now to update the GitHub actions as part of improving the scorecard.

cc: @expressjs/security-wg 