### PR TITLE
feat: don't compress on x-no-compression header

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,6 +256,12 @@ function chunkLength (chunk, encoding) {
 
 function shouldCompress (req, res) {
   var type = res.getHeader('Content-Type')
+  var noCompressionHeader = res.getHeader('x-no-compression')
+
+  if (noCompressionHeader) {
+    debug('%s not compressed', type)
+    return false
+  }
 
   if (type === undefined || !compressible(type)) {
     debug('%s not compressible', type)

--- a/test/compression.js
+++ b/test/compression.js
@@ -554,7 +554,7 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    it('should not set Vary headerh', function (done) {
+    it('should not set Vary header', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Cache-Control', 'no-transform')
         res.setHeader('Content-Type', 'text/plain')
@@ -565,6 +565,36 @@ describe('compression()', function () {
         .get('/')
         .set('Accept-Encoding', 'gzip')
         .expect('Cache-Control', 'no-transform')
+        .expect(shouldNotHaveHeader('Vary'))
+        .expect(200, done)
+    })
+  })
+
+  describe('when "X-No-Compression" request header', function () {
+    it('should not compress response', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.setHeader('X-No-Compression', '0')
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip, br')
+        .expect(shouldNotHaveHeader('Content-Encoding'))
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should not set Vary header', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.setHeader('X-No-Compression', '1')
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip, br')
         .expect(shouldNotHaveHeader('Vary'))
         .expect(200, done)
     })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

We should observe when `X-No-Compression` is sent in the request.  
