### PR TITLE
refactor: remove obsolete brotli and http2 support checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ The following compression codings are supported:
   - gzip
   - br (brotli)
 
-**Note** Brotli is supported only since Node.js versions v11.7.0 and v10.16.0.
-
 ## Install
 
 This is a [Node.js](https://nodejs.org/en/) module available through the

--- a/index.js
+++ b/index.js
@@ -31,18 +31,12 @@ module.exports = compression
 module.exports.filter = shouldCompress
 
 /**
- * @const
- * whether current node version has brotli support
- */
-var hasBrotliSupport = 'createBrotliCompress' in zlib
-
-/**
  * Module variables.
  * @private
  */
 var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
-var SUPPORTED_ENCODING = hasBrotliSupport ? ['br', 'gzip', 'deflate', 'identity'] : ['gzip', 'deflate', 'identity']
-var PREFERRED_ENCODING = hasBrotliSupport ? ['br', 'gzip'] : ['gzip']
+var SUPPORTED_ENCODING = ['br', 'gzip', 'deflate', 'identity']
+var PREFERRED_ENCODING = ['br', 'gzip']
 
 var encodingSupported = ['gzip', 'deflate', 'identity', 'br']
 
@@ -56,16 +50,12 @@ var encodingSupported = ['gzip', 'deflate', 'identity', 'br']
 
 function compression (options) {
   var opts = options || {}
-  var optsBrotli = {}
-
-  if (hasBrotliSupport) {
-    Object.assign(optsBrotli, opts.brotli)
-
-    var brotliParams = {}
-    brotliParams[zlib.constants.BROTLI_PARAM_QUALITY] = 4
-
-    // set the default level to a reasonable value with balanced speed/ratio
-    optsBrotli.params = Object.assign(brotliParams, optsBrotli.params)
+  var optsBrotli = {
+    ...opts.brotli,
+    params: {
+      [zlib.constants.BROTLI_PARAM_QUALITY]: 4, // set the default level to a reasonable value with balanced speed/ratio
+      ...opts.brotli?.params
+    }
   }
 
   // options

--- a/test/compression.js
+++ b/test/compression.js
@@ -6,25 +6,9 @@ var crypto = require('crypto')
 var http = require('http')
 var request = require('supertest')
 var zlib = require('zlib')
-
-var describeHttp2 = describe.skip
-try {
-  var http2 = require('http2')
-  describeHttp2 = describe
-} catch (err) {
-  if (err) {
-    console.log('http2 tests disabled.')
-  }
-}
+var http2 = require('http2')
 
 var compression = require('..')
-
-/**
- * @const
- * whether current node version has brotli support
- */
-var hasBrotliSupport = 'createBrotliCompress' in zlib
-var brotli = hasBrotliSupport ? it : it.skip
 
 describe('compression()', function () {
   it('should skip HEAD', function (done) {
@@ -322,7 +306,7 @@ describe('compression()', function () {
       .expect(200, done)
   })
 
-  describeHttp2('http2', function () {
+  describe('http2', function () {
     it('should work with http2 server', function (done) {
       var server = createHttp2Server({ threshold: 0 }, function (req, res) {
         res.setHeader(http2.constants.HTTP2_HEADER_CONTENT_TYPE, 'text/plain')
@@ -518,7 +502,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: br"', function () {
-    brotli('should respond with br', function (done) {
+    it('should respond with br', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -532,7 +516,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: br" and passing compression level', function () {
-    brotli('should respond with br', function (done) {
+    it('should respond with br', function (done) {
       var params = {}
       params[zlib.constants.BROTLI_PARAM_QUALITY] = 11
 
@@ -547,7 +531,7 @@ describe('compression()', function () {
         .expect('Content-Encoding', 'br', done)
     })
 
-    brotli('shouldn\'t break compression when gzip is requested', function (done) {
+    it('shouldn\'t break compression when gzip is requested', function (done) {
       var params = {}
       params[zlib.constants.BROTLI_PARAM_QUALITY] = 8
 
@@ -592,8 +576,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: gzip, br"', function () {
-    var brotli = hasBrotliSupport ? it : it.skip
-    brotli('should respond with br', function (done) {
+    it('should respond with br', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -605,9 +588,7 @@ describe('compression()', function () {
         .expect('Content-Encoding', 'br', done)
     })
 
-    brotli = hasBrotliSupport ? it.skip : it
-
-    brotli('should respond with gzip', function (done) {
+    it.skip('should respond with gzip', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -621,7 +602,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: deflate, gzip, br"', function () {
-    brotli('should respond with br', function (done) {
+    it('should respond with br', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -635,7 +616,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: gzip;q=1, br;q=0.3"', function () {
-    brotli('should respond with gzip', function (done) {
+    it('should respond with gzip', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -649,7 +630,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: gzip, br;q=0.8"', function () {
-    brotli('should respond with gzip', function (done) {
+    it('should respond with gzip', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -663,7 +644,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: gzip;q=0.001"', function () {
-    brotli('should respond with gzip', function (done) {
+    it('should respond with gzip', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -677,7 +658,7 @@ describe('compression()', function () {
   })
 
   describe('when "Accept-Encoding: deflate, br"', function () {
-    brotli('should respond with br', function (done) {
+    it('should respond with br', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')
@@ -828,7 +809,7 @@ describe('compression()', function () {
         .end()
     })
 
-    brotli('should flush small chunks for brotli', function (done) {
+    it('should flush small chunks for brotli', function (done) {
       var chunks = 0
       var next
       var server = createServer({ threshold: 0 }, function (req, res) {
@@ -934,7 +915,7 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    brotli('should compress when enforceEncoding is brotli', function (done) {
+    it('should compress when enforceEncoding is brotli', function (done) {
       var server = createServer({ threshold: 0, enforceEncoding: 'br' }, function (req, res) {
         res.setHeader('Content-Type', 'text/plain')
         res.end('hello, world')


### PR DESCRIPTION
Since the next major drops support for Node.js < v18 these checks are no longer needed.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->