### PR TITLE
refactor: use res.headersSent

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function compression (options) {
         return false
       }
 
-      if (!headersSent(res)) {
+      if (!res.headersSent) {
         this.writeHead(this.statusCode)
       }
 
@@ -104,7 +104,7 @@ function compression (options) {
         return false
       }
 
-      if (!headersSent(res)) {
+      if (!res.headersSent) {
         // estimate the length
         if (!this.getHeader('Content-Length')) {
           length = chunkLength(chunk, encoding)
@@ -297,18 +297,4 @@ function toBuffer (chunk, encoding) {
   return Buffer.isBuffer(chunk)
     ? chunk
     : Buffer.from(chunk, encoding)
-}
-
-/**
- * Determine if the response headers have been sent.
- *
- * @param {object} res
- * @returns {boolean}
- * @private
- */
-
-function headersSent (res) {
-  return typeof res.headersSent !== 'boolean'
-    ? Boolean(res._header)
-    : res.headersSent
 }


### PR DESCRIPTION
We no longer support older versions, and it's not advisable to use undocumented APIs.