### PR TITLE
new way to pass the configuration to the encodings

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,10 +36,8 @@ module.exports.filter = shouldCompress
  * @private
  */
 var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
-var SUPPORTED_ENCODING = ['br', 'gzip', 'deflate', 'identity']
+var ENCONDING_OPTIONS = ['br', 'gzip', 'deflate']
 var PREFERRED_ENCODING = ['br', 'gzip']
-
-var encodingSupported = ['gzip', 'deflate', 'identity', 'br']
 
 /**
  * Compress response data with gzip / deflate.
@@ -50,13 +48,14 @@ var encodingSupported = ['gzip', 'deflate', 'identity', 'br']
  */
 
 function compression (options) {
-  var opts = options || {}
+  const opts = options || {}
   const encodingOpts = opts?.encodings
-  var optsBrotli = {
-    ...encodingOpts?.brotli,
+  const encodingSupported = ENCONDING_OPTIONS.filter(enc => encodingOpts?.[enc] !== false)
+  const optsBrotli = {
+    ...encodingOpts?.br,
     params: {
       [zlib.constants.BROTLI_PARAM_QUALITY]: 4, // set the default level to a reasonable value with balanced speed/ratio
-      ...encodingOpts?.brotli?.params
+      ...encodingOpts?.br?.params
     }
   }
 
@@ -188,7 +187,7 @@ function compression (options) {
 
       // compression method
       var negotiator = new Negotiator(req)
-      var method = negotiator.encoding(SUPPORTED_ENCODING, PREFERRED_ENCODING)
+      var method = negotiator.encoding(encodingSupported, PREFERRED_ENCODING)
 
       // if no method is found, use the default encoding
       if (!req.headers['accept-encoding'] && encodingSupported.indexOf(enforceEncoding) !== -1) {

--- a/index.js
+++ b/index.js
@@ -51,11 +51,12 @@ var encodingSupported = ['gzip', 'deflate', 'identity', 'br']
 
 function compression (options) {
   var opts = options || {}
+  const encodingOpts = opts?.encodings
   var optsBrotli = {
-    ...opts.brotli,
+    ...encodingOpts?.brotli,
     params: {
       [zlib.constants.BROTLI_PARAM_QUALITY]: 4, // set the default level to a reasonable value with balanced speed/ratio
-      ...opts.brotli?.params
+      ...encodingOpts?.brotli?.params
     }
   }
 
@@ -202,11 +203,13 @@ function compression (options) {
 
       // compression stream
       debug('%s compression', method)
-      stream = method === 'gzip'
-        ? zlib.createGzip(opts)
-        : method === 'br'
-          ? zlib.createBrotliCompress(optsBrotli)
-          : zlib.createDeflate(opts)
+      if (method === 'gzip') {
+        stream = zlib.createGzip(encodingOpts?.gzip)
+      } else if (method === 'br') {
+        stream = zlib.createBrotliCompress(optsBrotli)
+      } else {
+        stream = zlib.createDeflate(encodingOpts?.deflate)
+      }
 
       // add buffered listeners to stream
       addListeners(stream, stream.on, listeners)

--- a/test/compression.js
+++ b/test/compression.js
@@ -51,6 +51,20 @@ describe('compression()', function () {
       .expect(200, 'hello, world', done)
   })
 
+  it('should skip if content-encondig is identity', function (done) {
+    var server = createServer({ threshold: 0 }, function (req, res) {
+      res.setHeader('Content-Type', 'text/plain')
+      res.end('hello, world')
+    })
+
+    request(server)
+      .get('/')
+      .set('Accept-Encoding', 'identity')
+      .expect(shouldNotHaveHeader('Content-Encoding'))
+      .expect(200, done)
+  })
+
+
   it('should set Vary', function (done) {
     var server = createServer({ threshold: 0 }, function (req, res) {
       res.setHeader('Content-Type', 'text/plain')
@@ -459,218 +473,307 @@ describe('compression()', function () {
     })
   })
 
-  describe('when "Accept-Encoding: gzip"', function () {
-    it('should respond with gzip', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
+  describe('encondigs', function () {
+    describe('when "Accept-Encoding: gzip"', function () {
+      it('when gzip is disable', function (done) {
+        var server = createServer({ threshold: 0, encodings: { gzip: false } }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip')
+          .expect(shouldNotHaveHeader('Content-Encoding'))
+          .expect(200, 'hello, world', done)
       })
 
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip')
-        .expect('Content-Encoding', 'gzip', done)
+      it('should respond with gzip', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+  
+      it('should return false writing after end', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+          assert.ok(res.write() === false)
+          assert.ok(res.end() === false)
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip')
+          .expect('Content-Encoding', 'gzip', done)
+      })
     })
-
-    it('should return false writing after end', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-        assert.ok(res.write() === false)
-        assert.ok(res.end() === false)
+  
+    describe('when "Accept-Encoding: deflate"', function () {
+      it('should respond with deflate', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate')
+          .expect('Content-Encoding', 'deflate', done)
       })
 
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip')
-        .expect('Content-Encoding', 'gzip', done)
+      it('when deflate is disable', function (done) {
+        var server = createServer({ threshold: 0, encodings: { deflate: false } }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate')
+          .expect(shouldNotHaveHeader('Content-Encoding'))
+          .expect(200, 'hello, world', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: br"', function () {
+      it('when brotli is disable should not compress', function (done) {  
+        var server = createServer({ threshold: 0, encodings: { br: false }}, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'br')
+          .expect(shouldNotHaveHeader('Content-Encoding'))
+          .expect(200, 'hello, world', done)
+      })
+
+      it('should respond with br', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'br')
+          .expect('Content-Encoding', 'br', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: br" and passing compression level', function () {
+      it('should respond with br', function (done) {
+        var params = {}
+        params[zlib.constants.BROTLI_PARAM_QUALITY] = 11
+  
+        var server = createServer({ threshold: 0, encodings: { br: { params: params } }}, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'br')
+          .expect('Content-Encoding', 'br', done)
+      })
+  
+      it('shouldn\'t break compression when gzip is requested', function (done) {
+        var params = {}
+        params[zlib.constants.BROTLI_PARAM_QUALITY] = 8
+  
+        var server = createServer({ threshold: 0, encodings: { br: { params: params } }}, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: gzip, deflate"', function () {
+      it('should respond with deflate when gzip is disable', function (done) {
+        var server = createServer({ threshold: 0, encodings: { gzip: false } }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip, deflate')
+          .expect('Content-Encoding', 'deflate', done)
+      })
+
+      it('should respond with gzip', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip, deflate')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: deflate, gzip"', function () {
+      it('should respond with gzip', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate, gzip')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: gzip, br"', function () {
+      it('should respond with gzip when brotli is disable', function (done) {
+        var server = createServer({ threshold: 0, encodings: { br: false } }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip, br')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+
+      it('should respond with br', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip, br')
+          .expect('Content-Encoding', 'br', done)
+      })  
+    })
+  
+    describe('when "Accept-Encoding: deflate, gzip, br"', function () {
+      it('should respond with gzip when brotli is disable', function (done) {
+        var server = createServer({ threshold: 0, encodings: { br: false } }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate, gzip, br')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+
+      it('should respond with deflate when brotli and gzip is disable', function (done) {
+        var server = createServer({ threshold: 0, encodings: { br: false, gzip: false } }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate, gzip, br')
+          .expect('Content-Encoding', 'deflate', done)
+      })
+
+      it('should respond with br', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate, gzip, br')
+          .expect('Content-Encoding', 'br', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: gzip;q=1, br;q=0.3"', function () {
+      it('should respond with gzip', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip;q=1, br;q=0.3')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: gzip, br;q=0.8"', function () {
+      it('should respond with gzip', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip, br;q=0.8')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: gzip;q=0.001"', function () {
+      it('should respond with gzip', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip;q=0.001')
+          .expect('Content-Encoding', 'gzip', done)
+      })
+    })
+  
+    describe('when "Accept-Encoding: deflate, br"', function () {
+      it('should respond with deflate when brotli is disable', function (done) {
+        var server = createServer({ threshold: 0, encodings: { br: false } }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate, br')
+          .expect('Content-Encoding', 'deflate', done)
+      })
+
+      it('should respond with br', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+  
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'deflate, br')
+          .expect('Content-Encoding', 'br', done)
+      })
     })
   })
-
-  describe('when "Accept-Encoding: deflate"', function () {
-    it('should respond with deflate', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'deflate')
-        .expect('Content-Encoding', 'deflate', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: br"', function () {
-    it('should respond with br', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'br')
-        .expect('Content-Encoding', 'br', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: br" and passing compression level', function () {
-    it('should respond with br', function (done) {
-      var params = {}
-      params[zlib.constants.BROTLI_PARAM_QUALITY] = 11
-
-      var server = createServer({ threshold: 0, brotli: { params: params } }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'br')
-        .expect('Content-Encoding', 'br', done)
-    })
-
-    it('shouldn\'t break compression when gzip is requested', function (done) {
-      var params = {}
-      params[zlib.constants.BROTLI_PARAM_QUALITY] = 8
-
-      var server = createServer({ threshold: 0, brotli: { params: params } }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip')
-        .expect('Content-Encoding', 'gzip', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: gzip, deflate"', function () {
-    it('should respond with gzip', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip, deflate')
-        .expect('Content-Encoding', 'gzip', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: deflate, gzip"', function () {
-    it('should respond with gzip', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'deflate, gzip')
-        .expect('Content-Encoding', 'gzip', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: gzip, br"', function () {
-    it('should respond with br', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip, br')
-        .expect('Content-Encoding', 'br', done)
-    })
-
-    it.skip('should respond with gzip', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'br, gzip')
-        .expect('Content-Encoding', 'gzip', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: deflate, gzip, br"', function () {
-    it('should respond with br', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'deflate, gzip, br')
-        .expect('Content-Encoding', 'br', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: gzip;q=1, br;q=0.3"', function () {
-    it('should respond with gzip', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip;q=1, br;q=0.3')
-        .expect('Content-Encoding', 'gzip', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: gzip, br;q=0.8"', function () {
-    it('should respond with gzip', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip, br;q=0.8')
-        .expect('Content-Encoding', 'gzip', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: gzip;q=0.001"', function () {
-    it('should respond with gzip', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip;q=0.001')
-        .expect('Content-Encoding', 'gzip', done)
-    })
-  })
-
-  describe('when "Accept-Encoding: deflate, br"', function () {
-    it('should respond with br', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'deflate, br')
-        .expect('Content-Encoding', 'br', done)
-    })
-  })
-
+  
   describe('when "Cache-Control: no-transform" response header', function () {
     it('should not compress response', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {


### PR DESCRIPTION
This is the new way I’m proposing to pass configuration to the encodings, which now does it in a more organized manner. Any suggestions are very welcome.

Adds the ability to disable supported encodings.

Closes #220 #25 #27