### PR TITLE
Release: 1.8.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-unreleased
+1.8.1 / 2025-07-17
 ==========
 
   * deps: on-headers@~1.1.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "compression",
   "description": "Node.js compression middleware",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"


### PR DESCRIPTION
## What's Changed
* fix(docs): update multiple links from http to https by @Phillip9587 in https://github.com/expressjs/compression/pull/222
* ci: add dependabot for github actions by @bjohansebas in https://github.com/expressjs/compression/pull/207
* build(deps): bump github/codeql-action from 2.23.2 to 3.28.15 by @dependabot[bot] in https://github.com/expressjs/compression/pull/228
* build(deps): bump ossf/scorecard-action from 2.3.1 to 2.4.1 by @dependabot[bot] in https://github.com/expressjs/compression/pull/229
* build(deps-dev): bump eslint-plugin-import from 2.26.0 to 2.31.0 by @dependabot[bot] in https://github.com/expressjs/compression/pull/230
* build(deps-dev): bump supertest from 6.2.3 to 6.3.4 by @dependabot[bot] in https://github.com/expressjs/compression/pull/231
* [StepSecurity] ci: Harden GitHub Actions by @step-security-bot in https://github.com/expressjs/compression/pull/235
* build(deps): bump github/codeql-action from 3.28.15 to 3.29.2 by @dependabot[bot] in https://github.com/expressjs/compression/pull/243
* build(deps): bump actions/upload-artifact from 4.3.1 to 4.6.2 by @dependabot[bot] in https://github.com/expressjs/compression/pull/239
* build(deps): bump ossf/scorecard-action from 2.4.1 to 2.4.2 by @dependabot[bot] in https://github.com/expressjs/compression/pull/240
* build(deps): bump actions/checkout from 4.1.1 to 4.2.2 by @dependabot[bot] in https://github.com/expressjs/compression/pull/241
* build(deps-dev): bump eslint-plugin-import from 2.31.0 to 2.32.0 by @dependabot[bot] in https://github.com/expressjs/compression/pull/244
* deps: on-headers@1.1.0 by @UlisesGascon in https://github.com/expressjs/compression/pull/246

## New Contributors
* @dependabot[bot] made their first contribution in https://github.com/expressjs/compression/pull/228
* @step-security-bot made their first contribution in https://github.com/expressjs/compression/pull/235

**Full Changelog**: https://github.com/expressjs/compression/compare/1.8.0...v1.8.1