### PR TITLE
Add support for zstd

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ The following compression codings are supported:
   - deflate
   - gzip
   - br (brotli)
+  - zstd (Zstandard)
 
-**Note** Brotli is supported only since Node.js versions v11.7.0 and v10.16.0.
+**Note** Brotli is supported only since Node.js versions v11.7.0 and v10.16.0. Zstd is supported only since Node.js v23.8.0 and v22.15.0.
 
 ## Install
 
@@ -46,9 +47,10 @@ as compressing will transform the body.
 #### Options
 
 `compression()` accepts these properties in the options object. In addition to
-those listed below, [zlib](https://nodejs.org/api/zlib.html) options may be
-passed in to the options object or
-[brotli](https://nodejs.org/api/zlib.html#zlib_class_brotlioptions) options.
+those listed below, [zlib](https://nodejs.org/api/zlib.html),
+[brotli](https://nodejs.org/api/zlib.html#zlib_class_brotlioptions), or
+[zstd](https://nodejs.org/api/zlib.html#class-zstdoptions) options may be
+passed in to the options object.
 
 ##### chunkSize
 
@@ -116,6 +118,11 @@ Type: `Object`
 
 This specifies the options for configuring Brotli. See [Node.js documentation](https://nodejs.org/api/zlib.html#class-brotlioptions) for a complete list of available options.
 
+##### zstd
+
+Type: `Object`
+
+This specifies the options for configuring Zstd. See [Node.js documentation](https://nodejs.org/api/zlib.html#class-zstdoptions) for a complete list of available options.
 
 ##### strategy
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "opencollective",
     "url": "https://opencollective.com/express"
   },
-  "keywords": ["compression", "gzip", "deflate", "middleware", "express", "brotli", "http", "stream"],
+  "keywords": ["compression", "gzip", "deflate", "middleware", "express", "brotli", "zstd", "http", "stream"],
   "dependencies": {
     "bytes": "3.1.2",
     "compressible": "~2.0.18",


### PR DESCRIPTION
Adds support for zstd, but keeps brotli as preferred.

Resolves #217

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
