### PR TITLE
chore(ci): npm-publish via reusable workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,14 @@
+name: Publish package to npm
+on:
+  release:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    uses: expressjs/ci-workflows/.github/workflows/release.yml@main
+    secrets:
+      NPM_PUBLISH: ${{ secrets.NPM_PUBLISH }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,14 +1,37 @@
 name: Publish package to npm
+
 on:
   release:
-    types: [created]
+    types: [published]
+
+concurrency:
+  group: "${{ github.workflow }} ✨ ${{ github.ref }}"
+  cancel-in-progress: false
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   publish:
-    uses: expressjs/ci-workflows/.github/workflows/release.yml@main
-    secrets:
-      NPM_PUBLISH: ${{ secrets.NPM_PUBLISH }}
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "lts/*"
+          registry-url: "https://registry.npmjs.org"
+
+      # npm stage publish requires npm >= 11.15.0
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Stage publish to npm
+        run: npm stage publish


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

Use central reusable workflow to publish on npm with 2fa

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
