### PR TITLE
fix: resolve #254 - preserve headers set via writeHead

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,9 @@ function compression (options) {
         return false
       }
 
-      if (!headersSent(res)) {
+      // Don't overwrite headers if already set via writeHead (e.g., with custom statusText)
+      // Check res._header to detect if writeHead was already called with headers
+      if (!headersSent(res) && !res._header) {
         this.writeHead(this.statusCode)
       }
 
@@ -115,7 +117,9 @@ function compression (options) {
         return false
       }
 
-      if (!headersSent(res)) {
+      // Don't overwrite headers if already set via writeHead (e.g., with custom statusText)
+      // Check res._header to detect if writeHead was already called with headers
+      if (!headersSent(res) && !res._header) {
         // estimate the length
         if (!this.getHeader('Content-Length')) {
           length = chunkLength(chunk, encoding)


### PR DESCRIPTION
## Bug (compression#254)

When user calls `res.writeHead(200, undefined, {'foo': 'bar'})` with custom headers, the compression middleware overwrites those headers when it calls `this.writeHead(this.statusCode)` without passing the headers.

## Fix
Check `res._header` to detect if writeHead was already called with headers, and skip calling writeHead again if headers exist.

## Verification
1. Setup compression middleware with filter returning false (no compression)
2. Call `res.writeHead(200, undefined, {'foo': 'bar'})`
3. Before fix: headers not set
4. After fix: headers preserved