### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -245,7 +245,7 @@ function compression (options) {
 }
 
 /**
- * Add bufferred listeners to stream
+ * Add buffered listeners to stream
  * @private
  */
 


### PR DESCRIPTION
Fixed typographical errors across documentation markdown files using codespell.