### PR TITLE
docs: update outdated Brotli note and fix npm install docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ The following compression codings are supported:
   - gzip
   - br (brotli)
 
-**Note** Brotli is supported only since Node.js versions v11.7.0 and v10.16.0.
+**Note** Brotli is available in all currently supported Node.js LTS versions (v18+).
 
 ## Install
 
 This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/). Installation is done using the
-[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):
+[`npm install` command](https://docs.npmjs.com/downloading-and-installing-packages-locally):
 
 ```bash
 $ npm install compression


### PR DESCRIPTION
- Updated the Brotli support note from v11.7.0/v10.16.0 to reflect that Brotli is available in all currently supported Node.js LTS versions (v18+)
- Fixed outdated npm install docs URL from /getting-started/ to /downloading-and-installing-packages-locally

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
