### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,16 @@
     "type": "opencollective",
     "url": "https://opencollective.com/express"
   },
-  "keywords": ["compression", "gzip", "deflate", "middleware", "express", "brotli", "http", "stream"],
+  "keywords": [
+    "compression",
+    "gzip",
+    "deflate",
+    "middleware",
+    "express",
+    "brotli",
+    "http",
+    "stream"
+  ],
   "dependencies": {
     "bytes": "3.1.2",
     "compressible": "~2.0.18",
@@ -48,5 +57,9 @@
     "test": "mocha --check-leaks --reporter spec",
     "test-ci": "nyc --reporter=lcov --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
+  },
+  "homepage": "https://github.com/expressjs/compression",
+  "bugs": {
+    "url": "https://github.com/expressjs/compression/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.