### PR TITLE
deps: update debug from 2.6.9 to ~4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,20 @@
     "type": "opencollective",
     "url": "https://opencollective.com/express"
   },
-  "keywords": ["compression", "gzip", "deflate", "middleware", "express", "brotli", "http", "stream"],
+  "keywords": [
+    "compression",
+    "gzip",
+    "deflate",
+    "middleware",
+    "express",
+    "brotli",
+    "http",
+    "stream"
+  ],
   "dependencies": {
     "bytes": "3.1.2",
     "compressible": "~2.0.18",
-    "debug": "2.6.9",
+    "debug": "~4.4.0",
     "negotiator": "~0.6.4",
     "on-headers": "~1.1.0",
     "safe-buffer": "5.2.1",


### PR DESCRIPTION
## Summary

Updates the `debug` runtime dependency from 2.6.9 (May 2017) to latest stable 4.4.x.

## Why

- `debug@2.6.9` is **9 years old** — predates Node.js security improvements
- compression has **20M+ weekly npm downloads**
- Same fix as submitted to `expressjs/morgan` (#364)

## What Changed

| Package | Before | After |
|---------|--------|-------|
| `debug` | `2.6.9` | `~4.4.0` |

## Verification

```
npm install && npm test
```

**56 passing, 0 failures**