### PR TITLE
fix: preserve headers when statusText is undefined in writeHead

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,6 +240,15 @@ function compression (options) {
       })
     })
 
+    var _writeHead = res.writeHead
+    res.writeHead = function writeHead (statusCode, reason, headers) {
+      if (arguments.length > 2 && typeof reason !== 'string') {
+        return _writeHead.call(this, statusCode, headers)
+      }
+
+      return _writeHead.apply(this, arguments)
+    }
+
     next()
   }
 }

--- a/test/compression.js
+++ b/test/compression.js
@@ -973,6 +973,93 @@ describe('compression()', function () {
         .expect(200, done)
     })
   })
+
+  describe('res.writeHead', function () {
+    it('should support headers with undefined statusMessage', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.writeHead(200, undefined, {
+          'Content-Type': 'text/plain',
+          'X-Custom': 'header'
+        })
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('X-Custom', 'header')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should support headers with string statusMessage', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.writeHead(200, 'OK', {
+          'Content-Type': 'text/plain',
+          'X-Custom': 'header'
+        })
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('X-Custom', 'header')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should support array headers with undefined statusMessage', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.writeHead(200, undefined, [
+          ['Content-Type', 'text/plain'],
+          ['X-Custom', 'array']
+        ])
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('X-Custom', 'array')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should support array headers with string statusMessage', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.writeHead(200, 'OK', [
+          ['Content-Type', 'text/plain'],
+          ['X-Custom', 'array']
+        ])
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('X-Custom', 'array')
+        .expect('Content-Encoding', 'gzip')
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should support uncompressed response with undefined statusMessage', function (done) {
+      var server = createServer({ filter: function () { return false } }, function (req, res) {
+        res.writeHead(200, undefined, {
+          'Content-Type': 'text/plain',
+          'X-Custom': 'header'
+        })
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('X-Custom', 'header')
+        .expect(shouldNotHaveHeader('Content-Encoding'))
+        .expect(200, 'hello, world', done)
+    })
+  })
 })
 
 function createServer (opts, fn) {


### PR DESCRIPTION
Fixes #254

### Description
When \es.writeHead(statusCode, reason, headers)\ is called with 3 arguments where \eason\/\statusText\ is \undefined\ (or not a string), the 3rd argument (\headers\) was not recognized by \on-headers\ and got dropped.

This wraps \es.writeHead\ in \index.js\ to forward \(statusCode, headers)\ when \rguments.length > 2 && typeof reason !== 'string'\, ensuring response headers are properly set and preserved.

### Changes
- Wrapped \es.writeHead\ in \index.js\ to normalize 3-argument \writeHead\ calls where \eason\ is not a string.
- Added comprehensive unit tests in \	est/compression.js\ covering \es.writeHead(200, undefined, headers)\ and \es.writeHead(200, 'OK', headers)\ with both object and array header forms.