### PR TITLE
test: run CI on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,3 +274,224 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: ./lcov.info
+
+  # Cross-platform lanes, following the pattern merged in expressjs/multer#1464
+  # and proposed in expressjs/body-parser#759 and expressjs/morgan#379: the
+  # legacy `test` job above keeps running the full historical matrix on ubuntu
+  # via nvm (it cannot run on the hosted windows/macos runners, which have no
+  # nvm), while this job exercises the suite on windows and macos via
+  # actions/setup-node for every Node.js version those runners can install
+  # natively.  It does not upload coverage artifacts, so the `coverage-node-*`
+  # artifact names of the ubuntu job stay unambiguous.
+  test-cross-platform:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - windows-latest
+        name:
+        - Node.js 10.x
+        - Node.js 11.x
+        - Node.js 12.x
+        - Node.js 13.x
+        - Node.js 14.x
+        - Node.js 15.x
+        - Node.js 16.x
+        - Node.js 17.x
+        - Node.js 18.x
+        - Node.js 19.x
+        - Node.js 20.x
+        - Node.js 21.x
+        - Node.js 22.x
+        - Node.js 23.x
+        - Node.js 24.x
+        - Node.js 25.x
+
+        include:
+        - name: Node.js 10.x
+          node-version: "10"
+          npm-i: mocha@8.4.0 supertest@6.1.6
+
+        - name: Node.js 11.x
+          node-version: "11"
+          npm-i: mocha@8.4.0 supertest@6.1.6
+
+        - name: Node.js 12.x
+          node-version: "12"
+          npm-i: "supertest@6.1.6"
+
+        - name: Node.js 13.x
+          node-version: "13"
+          npm-i: "supertest@6.1.6"
+
+        - name: Node.js 14.x
+          node-version: "14"
+
+        - name: Node.js 15.x
+          node-version: "15"
+          npm-i: "supertest@6.1.6"
+
+        - name: Node.js 16.x
+          node-version: "16"
+
+        - name: Node.js 17.x
+          node-version: "17"
+
+        - name: Node.js 18.x
+          node-version: "18"
+
+        - name: Node.js 19.x
+          node-version: "19"
+
+        - name: Node.js 20.x
+          node-version: "20"
+
+        - name: Node.js 21.x
+          node-version: "21"
+
+        - name: Node.js 22.x
+          node-version: "22"
+
+        - name: Node.js 23.x
+          node-version: "23"
+
+        - name: Node.js 24.x
+          node-version: "24"
+
+        - name: Node.js 25.x
+          node-version: "25"
+
+        # Windows on Node.js < 22 is not yet proven for this suite; keep those
+        # legs informational until measured, mirroring expressjs/multer#1464.
+        - name: Node.js 10.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 11.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 12.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 13.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 14.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 15.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 16.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 17.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 18.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 19.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 20.x
+          os: windows-latest
+          experimental: true
+
+        - name: Node.js 21.x
+          os: windows-latest
+          experimental: true
+
+        # macOS: Node.js < 16 has no darwin-arm64 builds (setup-node cannot
+        # install them natively and those legs would be permanently red), so
+        # they are skipped. 16.x-21.x run informational until measured;
+        # 22+ are required checks.
+        - name: Node.js 16.x
+          os: macos-latest
+          node-version: "16"
+          experimental: true
+
+        - name: Node.js 17.x
+          os: macos-latest
+          node-version: "17"
+          experimental: true
+
+        - name: Node.js 18.x
+          os: macos-latest
+          node-version: "18"
+          experimental: true
+
+        - name: Node.js 19.x
+          os: macos-latest
+          node-version: "19"
+          experimental: true
+
+        - name: Node.js 20.x
+          os: macos-latest
+          node-version: "20"
+          experimental: true
+
+        - name: Node.js 21.x
+          os: macos-latest
+          node-version: "21"
+          experimental: true
+
+        - name: Node.js 22.x
+          os: macos-latest
+          node-version: "22"
+
+        - name: Node.js 23.x
+          os: macos-latest
+          node-version: "23"
+
+        - name: Node.js 24.x
+          os: macos-latest
+          node-version: "24"
+
+        - name: Node.js 25.x
+          os: macos-latest
+          node-version: "25"
+
+    continue-on-error: ${{ matrix.experimental == true }}
+    steps:
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      with:
+        persist-credentials: false
+
+    - name: Install Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install npm module(s) ${{ matrix.npm-i }}
+      run: npm install --save-dev ${{ matrix.npm-i }}
+      if: matrix.npm-i != ''
+
+    - name: Install Node.js dependencies
+      run: npm install
+
+    - name: List environment
+      shell: bash
+      run: |
+        echo "node@$(node -v)"
+        echo "npm@$(npm -v)"
+        npm -s ls ||:
+
+    - name: Run tests
+      shell: bash
+      run: |
+        if npm -ps ls nyc | grep -q nyc; then
+          npm run test-ci
+        else
+          npm test
+        fi


### PR DESCRIPTION
## What

Exercise compression's test suite on Windows and macOS in CI, while preserving the existing Ubuntu/nvm matrix for historical Node.js versions.

## Why

The current workflow only runs its tests on `ubuntu-latest`. Adding native Windows and macOS coverage follows the cross-platform CI pattern already merged in expressjs/multer#1464 and proposed in expressjs/body-parser#759 and expressjs/morgan#379.

## Changes

- Add a `test-cross-platform` job using `actions/setup-node`.
- Run Node.js 10.x–25.x on `windows-latest`; Node.js 10.x–21.x remain informational until measured.
- Run Node.js 16.x–25.x on `macos-latest`; 16.x–21.x are informational and 22.x+ are required checks.
- Keep the existing `test` job unchanged so the historical Node.js 0.8–25.x Ubuntu/nvm coverage and existing check names remain intact.
- Do not upload coverage artifacts from the cross-platform job, so the `coverage-node-*` artifact names consumed by the `coverage` job stay unambiguous.
- Reuse the repository's pinned `actions/checkout` and `actions/setup-node` SHAs.

## Verification

- Windows local baseline on Node.js v24.12.0: `56 passing`.
- `npm run lint` passes locally.
- Workflow YAML parses successfully and `git diff --check` is clean.

As this is the first contribution from this fork to compression, the workflow may require maintainer approval before GitHub Actions runs it.
