### PR TITLE
fix: match no-transform directive case-insensitively

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var hasBrotliSupport = 'createBrotliCompress' in zlib
  * Module variables.
  * @private
  */
-var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
+var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
 var SUPPORTED_ENCODING = hasBrotliSupport ? ['br', 'gzip', 'deflate', 'identity'] : ['gzip', 'deflate', 'identity']
 var PREFERRED_ENCODING = hasBrotliSupport ? ['br', 'gzip'] : ['gzip']
 

--- a/test/compression.js
+++ b/test/compression.js
@@ -706,6 +706,21 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
+    it('should match directive case-insensitively', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.setHeader('Cache-Control', 'No-Transform')
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('Cache-Control', 'No-Transform')
+        .expect(shouldNotHaveHeader('Content-Encoding'))
+        .expect(200, 'hello, world', done)
+    })
+
     it('should not set Vary headerh', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Cache-Control', 'no-transform')


### PR DESCRIPTION
### Summary

- match the `Cache-Control: no-transform` directive case-insensitively, as required by RFC 9111
- add regression coverage for a mixed-case `No-Transform` response directive

### Root cause

The directive check used a case-sensitive regular expression, so valid spellings such as `No-Transform` and `NO-TRANSFORM` did not prevent compression.

### Verification

- `npm test` (57 passing, 1 pending)
- `npm run lint`
- `npm run test-ci` (100% statements/functions/lines, 95% branches)
- standalone A/B reproduction: lowercase, mixed-case, and uppercase directives now all omit `Content-Encoding`

Fixes #284