### PR TITLE
fix: match Cache-Control no-transform directive case-insensitively

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Match `Cache-Control: no-transform` directive case-insensitively
+
 1.8.1 / 2025-07-17
 ==========
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ var hasBrotliSupport = 'createBrotliCompress' in zlib
  * Module variables.
  * @private
  */
-var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
+var cacheControlNoTransformRegExp = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
 var SUPPORTED_ENCODING = hasBrotliSupport ? ['br', 'gzip', 'deflate', 'identity'] : ['gzip', 'deflate', 'identity']
 var PREFERRED_ENCODING = hasBrotliSupport ? ['br', 'gzip'] : ['gzip']
 

--- a/test/compression.js
+++ b/test/compression.js
@@ -706,6 +706,36 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
+    it('should not compress response when casing is "No-Transform"', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.setHeader('Cache-Control', 'No-Transform')
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('Cache-Control', 'No-Transform')
+        .expect(shouldNotHaveHeader('Content-Encoding'))
+        .expect(200, 'hello, world', done)
+    })
+
+    it('should not compress response when casing is "NO-TRANSFORM"', function (done) {
+      var server = createServer({ threshold: 0 }, function (req, res) {
+        res.setHeader('Cache-Control', 'NO-TRANSFORM')
+        res.setHeader('Content-Type', 'text/plain')
+        res.end('hello, world')
+      })
+
+      request(server)
+        .get('/')
+        .set('Accept-Encoding', 'gzip')
+        .expect('Cache-Control', 'NO-TRANSFORM')
+        .expect(shouldNotHaveHeader('Content-Encoding'))
+        .expect(200, 'hello, world', done)
+    })
+
     it('should not set Vary headerh', function (done) {
       var server = createServer({ threshold: 0 }, function (req, res) {
         res.setHeader('Cache-Control', 'no-transform')

--- a/test/compression.js
+++ b/test/compression.js
@@ -706,34 +706,21 @@ describe('compression()', function () {
         .expect(200, 'hello, world', done)
     })
 
-    it('should not compress response when casing is "No-Transform"', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Cache-Control', 'No-Transform')
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
+    ;['No-Transform', 'NO-TRANSFORM', 'public, No-Transform, max-age=60'].forEach(function (value) {
+      it('should not compress response when "Cache-Control: ' + value + '"', function (done) {
+        var server = createServer({ threshold: 0 }, function (req, res) {
+          res.setHeader('Cache-Control', value)
+          res.setHeader('Content-Type', 'text/plain')
+          res.end('hello, world')
+        })
+
+        request(server)
+          .get('/')
+          .set('Accept-Encoding', 'gzip')
+          .expect('Cache-Control', value)
+          .expect(shouldNotHaveHeader('Content-Encoding'))
+          .expect(200, 'hello, world', done)
       })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip')
-        .expect('Cache-Control', 'No-Transform')
-        .expect(shouldNotHaveHeader('Content-Encoding'))
-        .expect(200, 'hello, world', done)
-    })
-
-    it('should not compress response when casing is "NO-TRANSFORM"', function (done) {
-      var server = createServer({ threshold: 0 }, function (req, res) {
-        res.setHeader('Cache-Control', 'NO-TRANSFORM')
-        res.setHeader('Content-Type', 'text/plain')
-        res.end('hello, world')
-      })
-
-      request(server)
-        .get('/')
-        .set('Accept-Encoding', 'gzip')
-        .expect('Cache-Control', 'NO-TRANSFORM')
-        .expect(shouldNotHaveHeader('Content-Encoding'))
-        .expect(200, 'hello, world', done)
     })
 
     it('should not set Vary headerh', function (done) {


### PR DESCRIPTION
Fixes #284

Per [RFC 9111 Section 5.2](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2), Cache-Control directives are compared case-insensitively. Previously, \compression\ checked for \
o-transform\ case-sensitively, so headers like \Cache-Control: No-Transform\ or \Cache-Control: NO-TRANSFORM\ were not recognized and responses were still compressed.

### Changes
- Added the case-insensitive flag \/i\ to \cacheControlNoTransformRegExp\ in \index.js\.
- Added unit tests in \	est/compression.js\ ensuring that different casings of \
o-transform\ prevent compression.